### PR TITLE
fixed waiting-for-timeout disabled

### DIFF
--- a/OBS.WebSocket.NET/OBSWebsocket.cs
+++ b/OBS.WebSocket.NET/OBSWebsocket.cs
@@ -276,7 +276,7 @@ namespace OBS.WebSocket.NET
                 if (Connection.State == WebSocketState.Open)
                     break;
 
-            } while (startTime + Timeout < DateTime.Now);
+            } while (startTime + Timeout > DateTime.Now);
 
             if (Connection.State != WebSocketState.Open)
                 return;


### PR DESCRIPTION
I found that Connect(str, str) won't wait for connection, which causes authentication skipped.